### PR TITLE
Added transparency support for linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "autoprefixer": "^10.4.18",
         "clsx": "^2.1.0",
         "electron": "^28.2.0",
-        "electron-builder": "^24.9.1",
+        "electron-builder": "^24.13.3",
         "electron-vite": "^2.0.0",
         "eslint": "^8.56.0",
         "eslint-plugin-react": "^7.33.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "autoprefixer": "^10.4.18",
     "clsx": "^2.1.0",
     "electron": "^28.2.0",
-    "electron-builder": "^24.9.1",
+    "electron-builder": "^24.13.3",
     "electron-vite": "^2.0.0",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ function createWindow(): void {
     height: 670,
     show: false,
     autoHideMenuBar: true,
-    ...(process.platform === 'linux' ? { icon } : {}),
+    ...(process.platform === 'linux' ? { icon, transparent: true } : {}),
     center: true,
     title: 'Quartz',
     frame: false,


### PR DESCRIPTION
Added `transparent:true` in `index.ts`, which allows transparent windows to display properly on linux.  This is within the linux conditional, so it won't affect MacOS or Windows.